### PR TITLE
External chaincode sync should use PullAlways when updating

### DIFF
--- a/kubectl-hlf/cmd/externalchaincode/sync.go
+++ b/kubectl-hlf/cmd/externalchaincode/sync.go
@@ -180,7 +180,7 @@ func (c *syncExternalChaincodeCmd) updateChaincode(ctx context.Context, fabricCh
 		return err
 	}
 	fabricChaincode.Spec.Image = fabricChaincodeSpec.Image
-	fabricChaincode.Spec.ImagePullPolicy = fabricChaincodeSpec.ImagePullPolicy
+	fabricChaincode.Spec.ImagePullPolicy = corev1.PullAlways
 	fabricChaincode.Spec.Replicas = fabricChaincodeSpec.Replicas
 	fabricChaincode.Spec.PackageID = fabricChaincodeSpec.PackageID
 	fabricChaincode.Spec.ImagePullSecrets = fabricChaincodeSpec.ImagePullSecrets


### PR DESCRIPTION
We should use always when updating externalchaincode

<!--  Thanks for sending a pull request! 
-->


#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

Chaincode image not auto update when using external chaincode sync.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note
NONE
```

#### Additional documentation, usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.


-->
```docs
NONE
```
